### PR TITLE
feat: Enhance UI for Ball-by-Ball Replay and Page Layout

### DIFF
--- a/IPL-1.0/app.py
+++ b/IPL-1.0/app.py
@@ -186,7 +186,13 @@ def replay_match_view():
         session.pop('replay_match_id', None)
         return redirect(url_for('index', error_message="Error reading match data."))
 
-    return render_template('replay_ball_by_ball.html', full_match_data=full_match_data)
+    team1_s_name = full_match_data.get('team1_data', {}).get('name', full_match_data.get('team1_code', 'Team 1'))
+    team2_s_name = full_match_data.get('team2_data', {}).get('name', full_match_data.get('team2_code', 'Team 2'))
+
+    return render_template('replay_ball_by_ball.html',
+                           full_match_data=full_match_data,
+                           team1_short_name=team1_s_name,
+                           team2_short_name=team2_s_name)
 
 # Routes for MatchSimulator based interactive simulation (currently disconnected from main UI flow)
 # @app.route('/ball_by_ball_game_view')

--- a/IPL-1.0/templates/replay_ball_by_ball.html
+++ b/IPL-1.0/templates/replay_ball_by_ball.html
@@ -3,13 +3,69 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Match Replay</title>
+    <title>{{ team1_short_name }} vs {{ team2_short_name }} - IPL Replay</title>
     <style>
-        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; background-color: #1e1e1e; color: #fff; display: flex; justify-content: center; align-items: flex-start; min-height: 100vh; padding: 20px; box-sizing: border-box; }
-        .container { width: 100%; max-width: 960px; background: #2c2c2c; padding: 20px; border-radius: 10px; box-shadow: 0 0 20px rgba(0,0,0,0.5); }
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            background-color: #1e1e1e;
+            color: #fff;
+            padding-top: 80px; /* Adjusted for fixed header */
+            box-sizing: border-box;
+        }
+        .match-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 15px 25px;
+            background-color: #181818; /* Darker header */
+            color: #ffcc00;
+            border-bottom: 2px solid #ffcc00;
+            position: fixed; /* Fixed header */
+            top: 0;
+            left: 0;
+            width: 100%;
+            z-index: 1000;
+            box-sizing: border-box;
+        }
+        .header-title h1 {
+            margin: 0;
+            font-size: 1.6em;
+            font-weight: bold;
+            color: #ffcc00; /* Ensure h1 color is set if not inheriting properly */
+        }
+        .new-match-button {
+            padding: 10px 18px;
+            font-size: 1em;
+            background-color: #ffcc00;
+            color: #1e272e;
+            border: none;
+            border-radius: 25px;
+            cursor: pointer;
+            text-decoration: none;
+            font-weight: bold;
+            transition: background-color 0.2s ease;
+        }
+        .new-match-button:hover {
+            background-color: #e0b804;
+        }
+        hr.header-divider {
+            display: none;
+        }
 
-        h1, h2, h3 { text-align: center; color: #ffcc00; }
-        h1 { font-size: 2em; margin-bottom: 10px; }
+        .container {
+            width: 100%;
+            max-width: 960px;
+            background: #2c2c2c;
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0 0 20px rgba(0,0,0,0.5);
+            margin: 20px auto; /* Added margin for spacing from header if body padding-top is not enough */
+        }
+
+        /* Rest of existing styles from previous version, merged carefully */
+        h2, h3 { text-align: center; color: #ffcc00; }
+        /* h1 is now in header, so main page h1 can be removed or restyled if another exists */
         h2 { font-size: 1.6em; margin-bottom: 15px; border-bottom: 1px solid #ffcc00; padding-bottom: 10px;}
         h3 { font-size: 1.2em; margin-bottom: 10px; color: #eee;}
         .section { margin-bottom: 15px; padding: 12px; background-color: #3a3a3a; border-radius: 8px; }
@@ -40,8 +96,9 @@
 
         .win-message { text-align: center; font-size: 1.5em; color: #4CAF50; font-weight: bold; padding: 15px; background-color: #dff0d8; border: 1px solid #4CAF50; border-radius: 5px; color:#3c763d;}
         .hidden { display: none; }
-        a { color: #ffcc00; text-decoration: none; }
-        a:hover { text-decoration: underline;}
+        /* Removed general 'a' styling if not needed globally, or keep if other links exist */
+        /* a { color: #ffcc00; text-decoration: none; } */
+        /* a:hover { text-decoration: underline;} */
         .team-logo-pbs { width: 24px; height: 24px; margin-right: 8px; vertical-align: middle; border-radius: 50%; background-color: #fff; padding:1px; }
         .team-display { display: flex; align-items: center; margin-bottom: 5px;}
         .team-display .name {font-size: 1.1em; font-weight:bold;}
@@ -49,9 +106,22 @@
     </style>
 </head>
 <body>
+    <header class="match-header">
+        <div class="header-title">
+            <h1>{{ team1_short_name }} vs {{ team2_short_name }}</h1>
+        </div>
+        <div class="header-actions">
+            <form action="{{ url_for('index') }}" method="get" style="margin: 0;">
+                <button type="submit" class="new-match-button">New Match</button>
+            </form>
+        </div>
+    </header>
+    {# <hr class="header-divider"> #}  <!-- Divider can be part of header border-bottom -->
+
     <div class="container">
-        <h1>Match Replay</h1>
-        <p style="text-align:center;"><a href="{{ url_for('index') }}">New Match / Select Teams</a></p>
+        {# Removed the old H1 and "New Match / Select Teams" link from here #}
+        {# <h1>Match Replay</h1> #}
+        {# <p style="text-align:center;"><a href="{{ url_for('index') }}">New Match / Select Teams</a></p> #}
 
         <div id="tossDisplay" class="section"></div>
 
@@ -114,6 +184,9 @@
 
     <script>
         const fullMatchData = {{ full_match_data | tojson }};
+        // Ensure team short names are available to JS if needed, though already used in Jinja title/header
+        // const team1ShortName = "{{ team1_short_name }}";
+        // const team2ShortName = "{{ team2_short_name }}";
 
         const tossDisplayEl = document.getElementById('tossDisplay');
         const ledBallNumEl = document.getElementById('led-ball-number');
@@ -167,21 +240,24 @@
             return `${overs}.${ballsInOver}`;
         }
 
-        function parseEventStringForLed(eventString, ballData) {
-            let outcomeText = " ";
-            let outcomeClass = "led-runs-0";
+        function parseEventStringForLed(eventString) { // Removed ballData param as it wasn't used
+            let outcomeText = "..."; // Default for unparsed
+            let outcomeClass = "led-default";
 
             const eventLower = eventString.toLowerCase();
 
+            // Order of checks can be important
             if (eventLower.includes(" wicket") || eventLower.includes(" w ")) { outcomeClass = 'led-wicket'; outcomeText = "WICKET!"; }
             else if (eventLower.includes("wide")) { outcomeClass = 'led-extra'; outcomeText = "WIDE"; }
-            else if (eventLower.includes("six!") || eventLower.includes(" 6 run")) { outcomeClass = 'led-runs-456'; outcomeText = "6"; }
-            else if (eventLower.includes(" 4 run")) { outcomeClass = 'led-runs-456'; outcomeText = "4"; }
-            else if (eventLower.includes(" 1 run")) { outcomeClass = 'led-runs-123'; outcomeText = "1"; }
-            else if (eventLower.includes(" 2 run")) { outcomeClass = 'led-runs-123'; outcomeText = "2"; }
-            else if (eventLower.includes(" 3 run")) { outcomeClass = 'led-runs-123'; outcomeText = "3"; }
-            else if (eventLower.includes(" 0 run") || eventLower.endsWith(" 0")) { outcomeClass = 'led-runs-0'; outcomeText = "0"; }
-            else { outcomeClass = 'led-default'; outcomeText = '...'; }
+            // Add No Ball if logs distinguish it clearly
+            // else if (eventLower.includes("noball") || eventLower.includes("nb")) { outcomeClass = 'led-extra'; outcomeText = "NO BALL"; }
+            else if (eventLower.includes("six!") || eventLower.includes(" 6 runs") || eventString.match(/\s6\s/)) { outcomeClass = 'led-runs-456'; outcomeText = "6"; }
+            else if (eventLower.includes(" 4 runs") || eventString.match(/\s4\s/)) { outcomeClass = 'led-runs-456'; outcomeText = "4"; }
+            else if (eventLower.includes(" 5 runs") || eventString.match(/\s5\s/)) { outcomeClass = 'led-runs-456'; outcomeText = "5"; } // Rare
+            else if (eventLower.includes(" 3 runs") || eventString.match(/\s3\s/)) { outcomeClass = 'led-runs-123'; outcomeText = "3"; }
+            else if (eventLower.includes(" 2 runs") || eventString.match(/\s2\s/)) { outcomeClass = 'led-runs-123'; outcomeText = "2"; }
+            else if (eventLower.includes(" 1 run") || eventString.match(/\s1\s/)) { outcomeClass = 'led-runs-123'; outcomeText = "1"; }
+            else if (eventLower.includes(" 0 runs") || eventLower.includes("no run") || eventString.endsWith(" 0")) { outcomeClass = 'led-runs-0'; outcomeText = "0"; }
 
             return { text: outcomeText, cssClass: outcomeClass };
         }
@@ -197,9 +273,11 @@
             currentOversEl.textContent = oversStr;
             ledScoreEl.textContent = `${runningScoreInInnings}/${runningWicketsInInnings}`;
 
-            const parsedLedInfo = parseEventStringForLed(logEntry.event, logEntry);
+            const parsedLedInfo = parseEventStringForLed(logEntry.event);
             ledOutcomeEl.textContent = parsedLedInfo.text;
-            ledOutcomeEl.className = parsedLedInfo.cssClass;
+            // Clear previous color classes before adding new one
+            ledOutcomeEl.className = ''; // Remove all classes
+            ledOutcomeEl.classList.add(parsedLedInfo.cssClass); // Add the specific outcome class
 
             const ballNumMatch = logEntry.event.match(/^(\d+\.\d+)/);
             ledBallNumEl.textContent = ballNumMatch ? ballNumMatch[1] : oversStr;
@@ -246,13 +324,15 @@
             fullInningsLogEl.innerHTML = `<h3>Innings ${inningsNo}</h3>`;
             lastBallCommentaryEl.textContent = `Start of Innings ${inningsNo}.`;
             currentScoreEl.textContent = "0"; currentWicketsEl.textContent = "0"; currentOversEl.textContent = "0.0";
-            ledScoreEl.textContent = "0/0"; ledBallNumEl.textContent = "0.0"; ledOutcomeEl.className = "led-default"; ledOutcomeEl.textContent = "---";
+            ledScoreEl.textContent = "0/0"; ledBallNumEl.textContent = "0.0";
+            ledOutcomeEl.className = 'led-default'; ledOutcomeEl.textContent = "---";
+
 
             if (inningsNo === 2) {
                 targetToChase = fullMatchData.innings1_runs + 1;
                 targetScoreEl.textContent = targetToChase;
-                runsNeededEl.textContent = targetToChase; // Initially
-                ballsRemainingEl.textContent = 120;    // Initially
+                runsNeededEl.textContent = targetToChase;
+                ballsRemainingEl.textContent = 120;
                 targetInfoEl.classList.remove('hidden');
             } else {
                 targetInfoEl.classList.add('hidden');
@@ -261,7 +341,7 @@
 
         function initializeReplay() {
             ballEvents = innings1Log.concat(innings2Log);
-            if (ballEvents.length === 0 && (!innings1Log || innings1Log.length === 0)) { // Check if both are effectively empty
+            if (ballEvents.length === 0 && (!innings1Log || innings1Log.length === 0)) {
                 lastBallCommentaryEl.textContent = "No ball-by-ball data available for this match.";
                 disableControls();
                 winMessageContainerEl.textContent = fullMatchData.win_msg || "Match data incomplete.";
@@ -276,7 +356,7 @@
             winMessageContainerEl.classList.add('hidden');
             nextBallBtn.disabled = false;
             startAutoPlayBtn.disabled = false;
-            pauseAutoPlayBtn.classList.add('hidden'); // Ensure pause is hidden initially
+            pauseAutoPlayBtn.classList.add('hidden');
             simSpeedSelect.disabled = false;
         }
 
@@ -295,7 +375,7 @@
         }
 
         function handleNextBall() {
-            if (winMessageContainerEl.classList.contains('hidden') === false) return; // Match already ended
+            if (winMessageContainerEl.classList.contains('hidden') === false) return;
 
             currentBallOverallIndex++;
 
@@ -308,9 +388,9 @@
 
             let previousInningsNumber = currentInningsNumber;
             if (currentInningsNumber === 1 && currentBallOverallIndex >= innings1Log.length) {
-                if (innings2Log.length > 0) { // Only switch if there's a second innings log
+                if (innings2Log.length > 0) {
                     currentInningsNumber = 2;
-                } else { // No second innings log, means match ended after 1st.
+                } else {
                     handleEndOfMatch();
                     return;
                 }
@@ -318,15 +398,13 @@
 
             if (currentInningsNumber !== previousInningsNumber) {
                 setupInningsUI(2);
-                // runningLegalBallsInInnings will be set by currentBallEventData.balls from the first ball of 2nd innings
             }
 
             updateUIDisplay(currentBallEventData);
 
-            // Check for win conditions after updating UI
             if (currentInningsNumber === 2 && targetToChase > 0 && runningScoreInInnings >= targetToChase) {
                 handleEndOfMatch();
-            } else if (currentBallOverallIndex === ballEvents.length - 1) { // Last ball of all available logs
+            } else if (currentBallOverallIndex === ballEvents.length - 1) {
                 handleEndOfMatch();
             }
         }
@@ -340,15 +418,15 @@
                 const speed = parseInt(simSpeedSelect.value, 10);
 
                 function autoPlay() {
-                    if (!winMessageContainerEl.classList.contains('hidden')) { // Check if game ended by handleNextBall
+                    if (!winMessageContainerEl.classList.contains('hidden')) {
                         clearInterval(autoPlayInterval); autoPlayInterval = null;
                         pauseAutoPlayBtn.classList.add('hidden'); startAutoPlayBtn.classList.remove('hidden');
-                        disableControls(); // Ensure controls are fully disabled
+                        disableControls();
                         return;
                     }
                     handleNextBall();
                 }
-                autoPlay(); // Call once immediately
+                autoPlay();
                 if (!winMessageContainerEl.classList.contains('hidden')) return;
                 autoPlayInterval = setInterval(autoPlay, speed);
             }


### PR DESCRIPTION
This commit introduces several UI improvements to the ball-by-ball replay feature and page structure based on your feedback:

1.  **Improved LED Outcome Display:**
    *   The JavaScript logic responsible for parsing ball event strings
        in `replay_ball_by_ball.html` has been significantly enhanced.
    *   It now accurately identifies and displays text for runs scored
        (0, 1, 2, 3, 4, 5, 6), Wickets, and Wides on the LED-style display.
    *   Correct CSS classes are applied for color-coding these outcomes
        (e.g., green for no run, white for 1-3 runs, yellow for 4-6 runs,
        red for wickets, sky-blue for extras), providing clearer visual
        feedback for each ball.

2.  **Dynamic Page Title:**
    *   The HTML `<title>` of the `replay_ball_by_ball.html` page is now
        dynamically generated to include the names of the competing teams
        (e.g., "CSK vs MI - IPL Replay"), improving browser tab context.

3.  **New Header Bar:**
    *   A persistent header bar has been added to the top of the
        `replay_ball_by_ball.html` page.
    *   This header displays the dynamic match title (e.g., "CSK vs MI").
    *   It also includes a restyled "New Match" button, prominently placed
        (typically top-right), allowing you to easily navigate back to
        the team selection screen.

4.  **Backend Support for Dynamic Titles:**
    *   The `app.py` route (`replay_match_view`) has been updated to pass
        the short names of the participating teams to the replay template,
        enabling the dynamic title and header features.

These enhancements provide a more polished, informative, and user-friendly interface for the ball-by-ball match replay.