### PR TITLE
feat: Add Theme Toggle, Refine Scorecard Controls & Button Styles

### DIFF
--- a/IPL-1.0/templates/index.html
+++ b/IPL-1.0/templates/index.html
@@ -5,92 +5,196 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cricket Scorecard Generator</title>
     <style>
+        :root {
+            --body-bg: #f4f6f9;
+            --container-bg: #ffffff;
+            --text-color: #343a40;
+            --heading-color: #343a40;
+            --link-color: #007bff;
+            --link-hover-color: #0056b3;
+            --button-bg: #007bff;
+            --button-text: #ffffff;
+            --button-hover-bg: #0056b3;
+            --fab-bg: #007bff; /* Floating Action Button */
+            --fab-text: #ffffff;
+            --fab-hover-bg: #0056b3;
+
+            /* Tables */
+            --table-border-color: #ddd;
+            --table-header-bg: #4a6572; /* slate grey/blue */
+            --table-header-text: #ffffff;
+            --table-header-border-bottom: #34495e;
+            --table-row-odd-bg: #f9f9f9;
+            --table-row-hover-bg: #f1f1f1;
+
+            /* Summaries / Alerts */
+            --summary-toss-bg: #e9ecef;
+            --summary-toss-text: #495057;
+            --summary-toss-border: #ced4da;
+            --summary-result-bg: #d4edda; /* success green */
+            --summary-result-text: #155724;
+            --summary-result-border: #c3e6cb;
+
+            /* Commentary */
+            --commentary-header-bg: #546e7a;
+            --commentary-header-text: #ffffff;
+            --commentary-header-hover-bg: #455a64;
+            --commentary-content-bg: #ffffff;
+            --commentary-content-border: #ddd;
+            --commentary-entry-border: #eee;
+
+            /* Team Selection Area */
+            --team-selection-bg: #e9ecef;
+            --team-box-border: #ccc;
+            --team-box-bg: #fff;
+            --team-box-text: #333;
+            --team-box-shadow-color: rgba(0,0,0,0.1); /* Shadow color variable */
+
+            /* Toss Animation */
+            --toss-animation-bg: #f9f9f9;
+            --toss-coin-bg: #FFD700;
+            --toss-coin-border: #DAA520;
+            --toss-text-color: #333;
+        }
+
+        [data-theme="dark"] {
+            --body-bg: #1e1e1e;
+            --container-bg: #2c2c2c;
+            --text-color: #e0e0e0;
+            --heading-color: #f1c40f; /* Accent color for headings in dark mode */
+            --link-color: #f1c40f;
+            --link-hover-color: #e0b804;
+            --button-bg: #f1c40f;
+            --button-text: #1e1e1e;
+            --button-hover-bg: #e0b804;
+            --fab-bg: #f1c40f;
+            --fab-text: #1e1e1e;
+            --fab-hover-bg: #e0b804;
+
+            /* Tables */
+            --table-border-color: #4a6572; /* Darker borders */
+            --table-header-bg: #34495e; /* Dark blue/grey */
+            --table-header-text: #f1c40f; /* Accent text */
+            --table-header-border-bottom: #2c3e50;
+            --table-row-odd-bg: #3a3a3a;
+            --table-row-hover-bg: #4a4a4a;
+
+            /* Summaries / Alerts */
+            --summary-toss-bg: #3a3a3a;
+            --summary-toss-text: #e0e0e0;
+            --summary-toss-border: #4a4a4a;
+            --summary-result-bg: #27ae60; /* Brighter green on dark */
+            --summary-result-text: #ffffff;
+            --summary-result-border: #1f8a4c;
+
+            /* Commentary */
+            --commentary-header-bg: #34495e;
+            --commentary-header-text: #f1c40f;
+            --commentary-header-hover-bg: #4a6572;
+            --commentary-content-bg: #222;
+            --commentary-content-border: #444;
+            --commentary-entry-border: #444;
+
+            /* Team Selection Area */
+            --team-selection-bg: #222;
+            --team-box-border: #555;
+            --team-box-bg: #3a3a3a;
+            --team-box-text: #e0e0e0;
+            --team-box-shadow-color: rgba(0,0,0,0.3); /* Darker shadow color */
+
+            /* Toss Animation */
+            --toss-animation-bg: #2c2c2c;
+            --toss-coin-bg: #f1c40f; /* Keep coin bright */
+            --toss-coin-border: #DAA520;
+            --toss-text-color: #e0e0e0;
+        }
+
         body {
             font-family: Arial, sans-serif;
             margin: 0;
-            background-color: #f4f6f9; /* Updated */
+            background-color: var(--body-bg);
             padding-top: 20px;
             padding-bottom: 20px;
-            color: #343a40; /* Default text color for body */
+            color: var(--text-color);
         }
         .container {
             max-width: 800px;
             margin: auto;
-            background-color: #ffffff; /* Kept as white */
-            box-shadow: 0 0 15px rgba(0,0,0,0.15); /* Slightly enhanced shadow */
+            background-color: var(--container-bg);
+            box-shadow: 0 0 15px var(--team-box-shadow-color); /* Adjusted to use variable */
             padding: 20px;
             border-radius: 8px;
         }
         .team-selection {
             margin-bottom: 20px;
             padding: 20px;
-            border: 1px solid #ddd;
+            border: 1px solid var(--table-border-color); /* Using table border for consistency */
             border-radius: 5px;
-            background-color: #e9ecef; /* Kept or can be slightly lightened if needed */
+            background-color: var(--team-selection-bg);
         }
         h2 {
             text-align: center;
-            color: #343a40; /* Updated */
+            color: var(--heading-color);
         }
-        h3 { /* General h3, including the main match title */
+        h3 {
             text-align: center;
-            color: #343a40; /* Updated */
+            color: var(--heading-color);
             margin-bottom: 15px;
-            /* For scorecard_data.match_teams_title, consider adding a specific class if more styling is needed than just color,
-               or target it more specifically if possible. For now, this global h3 change will apply.
-               A bottom border could be: border-bottom: 1px solid #dee2e6; padding-bottom: 10px; */
         }
-        h4 { /* Innings titles, Toss/Result sub-titles */
+        h4 {
             text-align: center;
-            color: #343a40; /* Updated */
+            color: var(--heading-color);
             margin-top: 20px;
             margin-bottom: 10px;
         }
-        h5 { /* Bowling team titles */
-            color: #343a40; /* Updated */
+        h5 {
+            color: var(--heading-color);
             margin-top: 15px;
             margin-bottom: 5px;
-            text-align: left; /* Ensuring bowling titles are left-aligned */
+            text-align: left;
         }
         label {
             margin-right: 10px;
+            /* color handled by body */
         }
         select {
             padding: 10px;
             margin-right: 10px;
-            border: 1px solid #ccc;
+            border: 1px solid var(--table-border-color);
             border-radius: 4px;
             min-width: 100px;
+            background-color: var(--container-bg); /* Match container for inputs */
+            color: var(--text-color);
         }
-        button {
+        button { /* General button styling - primarily for sim buttons */
             padding: 10px 15px;
             margin-right: 10px;
-            background-color: #007bff;
-            color: white;
+            background-color: var(--button-bg);
+            color: var(--button-text);
             border: none;
             border-radius: 4px;
             cursor: pointer;
         }
         button:hover {
-            background-color: #0056b3;
+            background-color: var(--button-hover-bg);
         }
-        .sim-button {
+        .sim-button { /* Specific class for main action buttons if needed */
             margin-left: 10px;
             margin-right: 10px;
             padding: 10px 20px;
         }
-        button:disabled {
-            background-color: #cccccc;
-            color: #666666;
+        button:disabled { /* General disabled state */
+            background-color: #cccccc; /* Consider a variable: --button-disabled-bg */
+            color: #666666;       /* Consider a variable: --button-disabled-text */
             cursor: not-allowed;
             opacity: 0.5;
         }
         .scorecard-section {
             margin-bottom: 20px;
             padding: 15px;
-            border: 1px solid #ddd;
+            border: 1px solid var(--table-border-color);
             border-radius: 5px;
-            background-color: #fff;
+            background-color: var(--container-bg); /* Match container for sections */
         }
         table {
             width: 100%;
@@ -98,45 +202,45 @@
             margin-top: 15px;
             border-radius: 5px;
             overflow: hidden;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            box-shadow: 0 2px 4px var(--team-box-shadow-color); /* Adjusted */
         }
         th, td {
-            border: 1px solid #ddd;
+            border: 1px solid var(--table-border-color);
             padding: 12px;
             text-align: left;
         }
         th {
-            background-color: #4a6572; /* Updated */
-            color: #ffffff; /* Updated */
-            border-bottom: 2px solid #34495e; /* Updated */
+            background-color: var(--table-header-bg);
+            color: var(--table-header-text);
+            border-bottom: 2px solid var(--table-header-border-bottom);
         }
         tbody tr:nth-child(odd) {
-            background-color: #f9f9f9;
+            background-color: var(--table-row-odd-bg);
         }
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-row-hover-bg);
         }
         .hidden {
             display: none;
         }
-        .match-summary.toss-summary { /* More specific selector for toss if needed, or general .match-summary */
-            background-color: #e9ecef; /* Updated for Toss */
-            border: 1px solid #ced4da; /* Updated for Toss */
-            color: #495057; /* Updated for Toss */
+        .match-summary.toss-summary {
+            background-color: var(--summary-toss-bg);
+            border: 1px solid var(--summary-toss-border);
+            color: var(--summary-toss-text);
             padding: 15px;
             border-radius: 5px;
             margin-top: 15px;
         }
-        .match-summary h4 { /* Applies to h4 within .match-summary (like "Toss", "Result") */
+        .match-summary h4 {
             text-align: left;
             margin-top: 0;
-            color: inherit; /* Inherits color from .match-summary or .result-highlight */
+            color: inherit;
         }
-        .result-highlight { /* This is for the main match result message */
+        .result-highlight {
             margin-top: 20px;
-            background-color: #d4edda; /* Updated for Result */
-            color: #155724;    /* Updated for Result */
-            border: 1px solid #c3e6cb;  /* Updated for Result */
+            background-color: var(--summary-result-bg);
+            color: var(--summary-result-text);
+            border: 1px solid var(--summary-result-border);
             padding: 15px;
             text-align: center;
             border-radius: 5px;
@@ -148,43 +252,43 @@
         hr {
             border: 0;
             height: 1px;
-            background: #ddd;
+            background: var(--table-border-color); /* Use table border color for hr */
             margin-top: 25px;
             margin-bottom: 25px;
         }
-        p strong { /* Applies to Total score line and winner message strong tag */
-            font-size: 1.05em; /* Kept as is, can be increased if needed for Total */
+        p strong {
+            font-size: 1.05em;
         }
-        /* Style for the paragraph containing the total score */
-        .scorecard-section > p > strong { /* Targets <strong> inside <p> directly under .scorecard-section */
-             font-weight: 600; /* Slightly bolder if needed */
+        .scorecard-section > p > strong {
+             font-weight: 600;
         }
         .commentary-section {
             margin-top: 20px;
-            border: 1px solid #ddd;
+            border: 1px solid var(--commentary-content-border);
             border-radius: 5px;
+            background-color: var(--commentary-content-bg);
         }
         .commentary-header {
-            background-color: #546e7a; /* Updated */
-            color: white;
+            background-color: var(--commentary-header-bg);
+            color: var(--commentary-header-text);
             padding: 10px;
             cursor: pointer;
             border-radius: 5px 5px 0 0;
         }
         .commentary-header:hover {
-            background-color: #455a64; /* Slightly darker shade for hover */
+            background-color: var(--commentary-header-hover-bg);
         }
         .commentary-content {
             padding: 10px;
-            border-top: 1px solid #ddd;
+            border-top: 1px solid var(--commentary-content-border);
             max-height: 300px;
             overflow-y: auto;
-            display: none;
+            display: none; /* JS controlled */
         }
         .commentary-content p {
             margin: 5px 0;
             font-size: 0.9em;
-            border-bottom: 1px dashed #eee;
+            border-bottom: 1px dashed var(--commentary-entry-border);
             padding-bottom: 5px;
         }
         .commentary-content p:last-child {
@@ -203,14 +307,16 @@
             padding: 15px;
             text-align: center;
             cursor: pointer;
-            transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.3s ease; /* Added border-color transition */
+            transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.3s ease;
             border-radius: 10px;
-            background-color: #fff; /* Default background */
-            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+            background-color: var(--team-box-bg);
+            /* border is dynamically set by JS via team_data.colorPrimary, but we can set a default */
+            border: 2px solid var(--team-box-border);
+            box-shadow: 0 2px 5px var(--team-box-shadow-color);
         }
         .team-box:hover {
             transform: translateY(-5px) scale(1.03);
-            box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+            box-shadow: 0 4px 10px var(--team-box-shadow-color); /* Slightly darker/more prominent on hover */
         }
         .team-logo {
             width: 80px;
@@ -218,72 +324,108 @@
             border-radius: 50%;
             object-fit: contain;
             margin-bottom: 10px;
-            background-color: #ffffff;
+            background-color: var(--container-bg); /* Ensure logo bg matches container bg */
             padding: 5px;
-            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            box-shadow: 0 1px 3px var(--team-box-shadow-color);
         }
         .team-name {
             font-weight: bold;
             font-size: 0.9em;
-            color: #333; /* Default text color */
+            color: var(--team-box-text);
             margin-top: 5px;
-            transition: color 0.3s ease; /* Added color transition */
+            transition: color 0.3s ease;
         }
-        .team-box.selected-team1, .team-box.selected-team2 {
-            /* Enhanced shadow for selection, specific background/border set by JS */
-            box-shadow: 0 0 15px rgba(0, 100, 255, 0.6), 0 0 0 3px rgba(0, 100, 255, 0.8);
-        }
+        /* .team-box.selected-team1, .team-box.selected-team2 styling is mostly JS driven for box-shadow */
+
         /* Team Grid Styles END */
 
         /* Toss Animation Styles START */
         #toss-animation-container {
             text-align: center;
             padding: 20px;
-            border: 1px solid #ccc;
+            border: 1px solid var(--table-border-color);
             margin-bottom: 20px;
-            background-color: #f9f9f9;
+            background-color: var(--toss-animation-bg);
             border-radius: 8px;
         }
         #coin {
-            width: 80px; height: 80px; background-color: #FFD700; border: 2px solid #DAA520;
+            width: 80px; height: 80px;
+            background-color: var(--toss-coin-bg);
+            border: 2px solid var(--toss-coin-border);
             border-radius: 50%; margin: 0 auto 20px auto; display: flex;
             justify-content: center; align-items: center; font-size: 1.1em;
-            color: #4a4a4a; position: relative; transform-style: preserve-3d;
+            color: var(--text-color); /* To contrast with coin bg */
+            position: relative; transform-style: preserve-3d;
         }
         .coin-flipping { animation: flip-animation 0.25s linear infinite; }
         .coin-face { position: absolute; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; backface-visibility: hidden; }
         .coin-tails { transform: rotateY(180deg); }
         @keyframes flip-animation { 0% { transform: rotateY(0deg); } 100% { transform: rotateY(360deg); } }
-        #toss-text-announcement { font-size: 1.2em; min-height: 2.5em; color: #333; }
+        #toss-text-announcement {
+            font-size: 1.2em;
+            min-height: 2.5em;
+            color: var(--toss-text-color);
+        }
         /* Toss Animation Styles END */
 
         .floating-action-button {
             position: fixed;
-            bottom: 60px; /* Adjusted for approximate centering of 80px button with 50-100px margin */
-            right: 60px;  /* Adjusted */
-            width: 80px;
-            height: 80px;
-            border-radius: 50%;
-            background-color: #007bff; /* Example color */
-            color: white;
+            bottom: 50px;
+            right: 50px;
+            width: auto;
+            min-width: 140px;
+            height: 55px;
+            padding: 0 20px;
+            border-radius: 28px;
+            background-color: var(--fab-bg);
+            color: var(--fab-text);
             text-align: center;
-            font-size: 13px; /* Small font for longer text */
-            line-height: 1.3; /* Adjust for text fitting */
+            font-size: 14px;
+            font-weight: bold;
+            line-height: 55px;
             border: none;
-            box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.3); /* This shadow might need its own variable if it changes significantly */
             cursor: pointer;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 5px; /* Add padding to prevent text overflow */
-            z-index: 1000; /* Ensure it's above other content */
+            z-index: 1000;
+            transition: background-color 0.2s ease, box-shadow 0.2s ease;
         }
+
         .floating-action-button:hover {
-            background-color: #0056b3; /* Darker shade on hover */
+            background-color: var(--fab-hover-bg);
+            box-shadow: 0 6px 16px rgba(0,0,0,0.35); /* This shadow might need its own variable */
         }
+
+        #themeToggleBtn {
+            background-color: var(--button-bg, #007bff); /* Default if var not ready */
+            color: var(--button-text, #ffffff);
+            border: 1px solid var(--button-bg, #007bff);
+            border-radius: 5px;
+            padding: 8px 12px;
+            position: fixed;
+            top: 20px;
+            right: 20px; /* Positioned top-right */
+            z-index: 2000; /* Ensure it's above other content */
+            cursor: pointer;
+            transition: background-color 0.3s ease, color 0.3s ease;
+        }
+
+        #themeToggleBtn:hover {
+            background-color: var(--button-hover-bg, #0056b3);
+        }
+
+        /* Adjustments for theme toggle button text color in dark mode if button doesn't fully use theme vars */
+        [data-theme="dark"] #themeToggleBtn {
+            background-color: var(--button-bg); /* Uses dark theme button variables */
+            color: var(--button-text);
+            border-color: var(--button-bg);
+       }
+       [data-theme="dark"] #themeToggleBtn:hover {
+            background-color: var(--button-hover-bg);
+       }
     </style>
 </head>
 <body>
+    <button id="themeToggleBtn" style="position: fixed; top: 20px; right: 20px; padding: 8px 12px; z-index: 1001; cursor: pointer;">Toggle Theme</button>
     <div class="container">
         <h2>Cricket Scorecard Generator</h2>
 
@@ -555,6 +697,40 @@
                 }
             }
         });
+
+        const themeToggleBtn = document.getElementById('themeToggleBtn');
+        const currentTheme = localStorage.getItem('theme'); // Use 'theme' as the key
+
+        // Function to apply theme (sets data-attribute on body)
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                document.body.setAttribute('data-theme', 'dark');
+                if (themeToggleBtn) themeToggleBtn.textContent = 'Light Mode'; // Update button text
+            } else {
+                document.body.setAttribute('data-theme', 'light'); // Default to light
+                if (themeToggleBtn) themeToggleBtn.textContent = 'Dark Mode'; // Update button text
+            }
+        }
+
+        // Apply saved theme on initial load
+        if (currentTheme) {
+            applyTheme(currentTheme);
+        } else {
+            // If no theme saved, default to light and update button text accordingly
+            applyTheme('light');
+        }
+
+        // Event listener for the button
+        if (themeToggleBtn) {
+            themeToggleBtn.addEventListener('click', () => {
+                let newTheme = 'light'; // Default to light if current is dark or not set
+                if (document.body.getAttribute('data-theme') === 'light') {
+                    newTheme = 'dark';
+                }
+                applyTheme(newTheme);
+                localStorage.setItem('theme', newTheme); // Save new preference
+            });
+        }
     </script>
 </body>
 </html>

--- a/IPL-1.0/templates/replay_ball_by_ball.html
+++ b/IPL-1.0/templates/replay_ball_by_ball.html
@@ -5,11 +5,163 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ team1_short_name }} vs {{ team2_short_name }} - IPL Replay</title>
     <style>
+        :root { /* Light Theme (Default) */
+            --body-bg: #f4f6f9;
+            --header-bg: #ffffff;
+            --header-text: #333;
+            --header-accent: #007bff;
+            --new-match-button-bg: #007bff;
+            --new-match-button-text: #ffffff;
+            --new-match-button-hover-bg: #0056b3;
+
+            --container-bg: #ffffff;
+            --section-bg: #f0f0f0;
+            --text-color: #343a40;
+            --heading-color: #007bff;
+            --subheading-color: #4a6572;
+            --accent-color: #007bff;
+            --player-highlight-color: #d9534f;
+
+            /* LED Display */
+            --led-display-bg: #e9ecef;
+            --led-display-span-text: #343a40; /* General text for non-outcome spans */
+            --led-runs-0-bg: #d4edda;
+            --led-runs-0-text: #155724;
+            --led-runs-123-bg: #cfe2ff;
+            --led-runs-123-text: #084298;
+            --led-runs-456-bg: #fff3cd;
+            --led-runs-456-text: #664d03;
+            --led-wicket-bg: #f8d7da;
+            --led-wicket-text: #58151c;
+            --led-extra-bg: #cff4fc;
+            --led-extra-text: #055160;
+            --led-default-bg: #e9ecef;
+            --led-default-text: #495057;
+
+            /* Commentary & Log */
+            --commentary-bg: #f8f9fa; /* Section bg for commentary box */
+            --last-ball-commentary-bg: #e9ecef; /* Specific bg for last ball text area */
+            --log-bg: #f8f9fa;  /* Section bg for full log box */
+            --full-innings-log-bg: #e9ecef; /* Specific bg for log scroll area */
+            --log-entry-border: #dee2e6;
+
+            /* Win Message */
+            --win-message-bg: #d1ecf1;
+            --win-message-text: #0c5460;
+            --win-message-border: #bee5eb;
+
+            /* Bottom Control Bar */
+            --control-bar-bg: #f8f9fa;
+            --control-bar-button-bg: #007bff;
+            --control-bar-button-text: #ffffff;
+            --control-bar-button-border: #007bff;
+            --control-bar-button-hover-bg: #0056b3;
+            --control-bar-button-hover-text: #ffffff;
+            --control-bar-button-disabled-bg: #cccccc;
+            --control-bar-button-disabled-text: #666666;
+            --control-bar-button-disabled-border: #cccccc;
+            --control-bar-select-bg: #ffffff;
+            --control-bar-select-text: #343a40;
+            --control-bar-select-border: #ced4da;
+            --control-bar-label-text: #343a40;
+
+            /* Scorecard Tables (Modal & First Innings) */
+            --modal-overlay-bg: rgba(0, 0, 0, 0.5);
+            --modal-content-bg: #ffffff;
+            --scorecard-table-text: #343a40;
+            --scorecard-table-header-bg: #e9ecef;
+            --scorecard-table-header-text: #007bff;
+            --scorecard-table-border: #dee2e6;
+            --scorecard-table-row-odd-bg: #f8f9fa;
+            --scorecard-table-row-hover-bg: #e9ecef;
+            --modal-close-button-text: #007bff;
+            --modal-close-button-hover-text: #0056b3;
+            --result-highlight-replay-bg: #d1ecf1;
+            --result-highlight-replay-text: #0c5460;
+            --first-innings-scorecard-bg: #e9ecef; /* Similar to other sections */
+        }
+
+        [data-theme="dark"] {
+            --body-bg: #1e1e1e;
+            --header-bg: #181818;
+            --header-text: #f1c40f;
+            --header-accent: #f1c40f;
+            --new-match-button-bg: #f1c40f;
+            --new-match-button-text: #1e272e;
+            --new-match-button-hover-bg: #e0b804;
+
+            --container-bg: #2c2c2c;
+            --section-bg: #3a3a3a;
+            --text-color: #fff;
+            --heading-color: #ffcc00;
+            --subheading-color: #eee;
+            --accent-color: #ffcc00;
+            --player-highlight-color: #ffeb3b;
+
+            /* LED Display */
+            --led-display-bg: #111;
+            --led-display-span-text: #fff; /* General text for non-outcome spans */
+            --led-runs-0-bg: #7f8c8d;
+            --led-runs-0-text: white;
+            --led-runs-123-bg: #ecf0f1;
+            --led-runs-123-text: #2c3e50;
+            --led-runs-456-bg: #f1c40f;
+            --led-runs-456-text: #333;
+            --led-wicket-bg: #e74c3c;
+            --led-wicket-text: white;
+            --led-extra-bg: #3498db;
+            --led-extra-text: white;
+            --led-default-bg: #bdc3c7;
+            --led-default-text: #333;
+
+            /* Commentary & Log */
+            --commentary-bg: #3a3a3a; /* Section bg */
+            --last-ball-commentary-bg: #4a4a4a;
+            --log-bg: #3a3a3a; /* Section bg */
+            --full-innings-log-bg: #222;
+            --log-entry-border: #444;
+
+            /* Win Message */
+            --win-message-bg: #dff0d8;
+            --win-message-text: #3c763d;
+            --win-message-border: #4CAF50;
+
+            /* Bottom Control Bar */
+            --control-bar-bg: #1e272e;
+            --control-bar-button-bg: #2c3e50;
+            --control-bar-button-text: #f1c40f;
+            --control-bar-button-border: #f1c40f;
+            --control-bar-button-hover-bg: #f1c40f;
+            --control-bar-button-hover-text: #1e272e;
+            --control-bar-button-disabled-bg: #3a3a3a;
+            --control-bar-button-disabled-text: #777777;
+            --control-bar-button-disabled-border: #555555;
+            --control-bar-select-bg: #2c3e50;
+            --control-bar-select-text: white;
+            --control-bar-select-border: #f1c40f;
+            --control-bar-label-text: #ecf0f1;
+
+            /* Scorecard Tables (Modal & First Innings) */
+            --modal-overlay-bg: rgba(0, 0, 0, 0.85);
+            --modal-content-bg: #2c3e50;
+            --scorecard-table-text: #ecf0f1;
+            --scorecard-table-header-bg: #34495e;
+            --scorecard-table-header-text: #f1c40f;
+            --scorecard-table-border: #4a6572;
+            --scorecard-table-row-odd-bg: #3b5363;
+            --scorecard-table-row-hover-bg: #4a6572;
+            --modal-close-button-text: #f1c40f;
+            --modal-close-button-hover-text: #ffffff;
+            --result-highlight-replay-bg: #27ae60;
+            --result-highlight-replay-text: white;
+            --first-innings-scorecard-bg: #283740; /* Original dark theme color */
+        }
+
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             margin: 0;
-            background-color: #1e1e1e;
-            color: #fff;
+            background-color: var(--body-bg);
+            color: var(--text-color);
             padding-top: 70px; /* For fixed header */
             padding-bottom: 75px; /* For fixed bottom control bar */
             box-sizing: border-box;
@@ -19,9 +171,9 @@
             justify-content: space-between;
             align-items: center;
             padding: 15px 25px;
-            background-color: #181818;
-            color: #f1c40f;
-            border-bottom: 2px solid #f1c40f;
+            background-color: var(--header-bg);
+            color: var(--header-text); /* Fallback, h1 has its own color */
+            border-bottom: 2px solid var(--header-accent);
             position: fixed;
             top: 0;
             left: 0;
@@ -33,13 +185,13 @@
             margin: 0;
             font-size: 1.6em;
             font-weight: bold;
-            color: #f1c40f;
+            color: var(--header-accent);
         }
         .new-match-button {
             padding: 10px 18px;
             font-size: 1em;
-            background-color: #f1c40f;
-            color: #1e272e;
+            background-color: var(--new-match-button-bg);
+            color: var(--new-match-button-text);
             border: none;
             border-radius: 25px;
             cursor: pointer;
@@ -48,43 +200,78 @@
             transition: background-color 0.2s ease;
         }
         .new-match-button:hover {
-            background-color: #e0b804;
+            background-color: var(--new-match-button-hover-bg);
         }
         .container {
             width: 100%;
             max-width: 960px;
-            background: #2c2c2c;
+            background: var(--container-bg);
             padding: 20px;
             border-radius: 10px;
-            box-shadow: 0 0 20px rgba(0,0,0,0.5);
+            box-shadow: 0 0 20px rgba(0,0,0,0.5); /* This shadow is quite dark, might need adjustment or variable */
             margin: 0 auto 20px auto; /* Adjusted margin for body padding */
         }
-        h2, h3 { text-align: center; color: #ffcc00; }
-        h2 { font-size: 1.6em; margin-bottom: 15px; border-bottom: 1px solid #ffcc00; padding-bottom: 10px;}
-        h3 { font-size: 1.2em; margin-bottom: 10px; color: #eee;}
-        .section { margin-bottom: 15px; padding: 12px; background-color: #3a3a3a; border-radius: 8px; }
+        h2 {
+            text-align: center;
+            color: var(--heading-color);
+            font-size: 1.6em; margin-bottom: 15px;
+            border-bottom: 1px solid var(--accent-color);
+            padding-bottom: 10px;
+        }
+        h3 { /* Also applies to static h3 in scorecard displays */
+            text-align: center;
+            color: var(--subheading-color);
+            font-size: 1.2em;
+            margin-bottom: 10px;
+        }
+        /* Specific H3s if needed, e.g. scorecard titles */
+        #firstInningsScorecardDisplay h3, #finalScorecardModal h2 { /* Modal h2 is styled like a prominent h3 */
+             color: var(--heading-color); /* Use main heading color for these titles */
+        }
+        .section {
+            margin-bottom: 15px;
+            padding: 12px;
+            background-color: var(--section-bg);
+            border-radius: 8px;
+        }
         .section p { margin: 6px 0; font-size: 1em; }
-        .section strong { color: #ffcc00; }
+        .section strong { color: var(--accent-color); }
 
-        #led-display { text-align: center; padding: 15px; background-color: #111; border-radius: 8px; margin-bottom: 15px; font-size: 1.5em; display: flex; justify-content: space-around; align-items: center; flex-wrap: wrap; }
-        #led-display span { padding: 8px 15px; border-radius: 5px; min-width: 80px; display: inline-block; margin: 5px; text-align:center; }
+        #led-display {
+            text-align: center; padding: 15px;
+            background-color: var(--led-display-bg);
+            border-radius: 8px; margin-bottom: 15px; font-size: 1.5em;
+            display: flex; justify-content: space-around; align-items: center; flex-wrap: wrap;
+        }
+        #led-display span { /* For non-outcome spans like "Ball:", "Score:" */
+            padding: 8px 15px; border-radius: 5px;
+            min-width: 80px; display: inline-block; margin: 5px; text-align:center;
+            color: var(--led-display-span-text); /* Ensure text is visible on --led-display-bg */
+        }
         #led-ball-outcome { font-weight: bold; }
-        .led-runs-0 { background-color: #7f8c8d; color: white; } /* Changed: Grey for dot ball */
-        .led-runs-123 { background-color: #ecf0f1; color: #2c3e50; }
-        .led-runs-456 { background-color: #f1c40f; color: #333; }
-        .led-wicket { background-color: #e74c3c; color: white; }
-        .led-extra { background-color: #3498db; color: white; }
-        .led-default { background-color: #bdc3c7; color: #333; }
+        .led-runs-0 { background-color: var(--led-runs-0-bg); color: var(--led-runs-0-text); }
+        .led-runs-123 { background-color: var(--led-runs-123-bg); color: var(--led-runs-123-text); }
+        .led-runs-456 { background-color: var(--led-runs-456-bg); color: var(--led-runs-456-text); }
+        .led-wicket { background-color: var(--led-wicket-bg); color: var(--led-wicket-text); }
+        .led-extra { background-color: var(--led-extra-bg); color: var(--led-extra-text); }
+        .led-default { background-color: var(--led-default-bg); color: var(--led-default-text); }
 
-        .player-highlight { font-weight: bold; color: #ffeb3b; }
+        .player-highlight { font-weight: bold; color: var(--player-highlight-color); }
 
-        #last-ball-commentary { font-size: 1.1em; text-align: center; min-height: 25px; padding: 8px; background-color: #4a4a4a; border-radius: 5px;}
-        #full-innings-log { max-height: 150px; overflow-y: auto; padding: 8px; background-color: #222; border-radius: 5px; font-size: 0.85em; }
-        .log-entry { border-bottom: 1px solid #444; padding: 5px 0; }
+        .commentary-box { background-color: var(--commentary-bg); }
+        #last-ball-commentary { font-size: 1.1em; text-align: center; min-height: 25px; padding: 8px; background-color: var(--last-ball-commentary-bg); border-radius: 5px;}
+        .full-log-box { background-color: var(--log-bg); }
+        #full-innings-log { max-height: 150px; overflow-y: auto; padding: 8px; background-color: var(--full-innings-log-bg); border-radius: 5px; font-size: 0.85em; }
+        .log-entry { border-bottom: 1px solid var(--log-entry-border); padding: 5px 0; }
         .log-entry:last-child { border-bottom: none; }
-        .win-message { text-align: center; font-size: 1.5em; color: #4CAF50; font-weight: bold; padding: 15px; background-color: #dff0d8; border: 1px solid #4CAF50; border-radius: 5px; color:#3c763d;}
+        .win-message {
+            text-align: center; font-size: 1.5em; font-weight: bold; padding: 15px;
+            background-color: var(--win-message-bg);
+            border: 1px solid var(--win-message-border);
+            border-radius: 5px; color: var(--win-message-text);
+        }
         .hidden { display: none; }
-        .team-logo-pbs { width: 24px; height: 24px; margin-right: 8px; vertical-align: middle; border-radius: 50%; background-color: #fff; padding:1px; }
+        .team-logo-pbs { width: 24px; height: 24px; margin-right: 8px; vertical-align: middle; border-radius: 50%; background-color: var(--container-bg); padding:1px; }
         .team-display { display: flex; align-items: center; margin-bottom: 5px;}
         .team-display .name {font-size: 1.1em; font-weight:bold;}
         .team-display .score-details {font-size: 1em; margin-left:8px;}
@@ -92,14 +279,16 @@
         /* Bottom Control Bar Styles START */
         .bottom-control-bar {
             position: fixed; bottom: 0; left: 0; width: 100%;
-            background-color: #1e272e; color: white; padding: 12px 0; /* Slightly more padding */
+            background-color: var(--control-bar-bg);
+            color: var(--control-bar-label-text); /* Text color for labels inside bar */
+            padding: 12px 0;
             display: flex; justify-content: space-evenly; align-items: center;
             z-index: 1010; box-shadow: 0 -2px 8px rgba(0,0,0,0.3); box-sizing: border-box;
         }
         .control-bar-button {
-            background-color: #2c3e50; /* Darker, matching select bg */
-            color: #f1c40f;           /* Yellow text */
-            border: 1px solid #f1c40f; /* Yellow border */
+            background-color: var(--control-bar-button-bg);
+            color: var(--control-bar-button-text);
+            border: 1px solid var(--control-bar-button-border);
             padding: 10px 18px;
             border-radius: 20px;
             cursor: pointer;
@@ -109,22 +298,22 @@
             margin: 0 8px; /* Adjusted margin */
         }
         .control-bar-button:hover {
-            background-color: #f1c40f; /* Yellow background on hover */
-            color: #1e272e;           /* Dark text on hover */
-            border-color: #f1c40f;    /* Keep border color or make it match new bg */
+            background-color: var(--control-bar-button-hover-bg);
+            color: var(--control-bar-button-hover-text);
+            border-color: var(--control-bar-button-hover-bg); /* Border matches hover background */
         }
         .control-bar-button:disabled {
-            background-color: #3a3a3a; /* Darker grey for disabled */
-            color: #777777;
-            border-color: #555555;
+            background-color: var(--control-bar-button-disabled-bg);
+            color: var(--control-bar-button-disabled-text);
+            border-color: var(--control-bar-button-disabled-border);
             cursor: not-allowed;
         }
         .control-bar-select {
             padding: 9px 12px; /* Slightly adjust padding for consistency */
             border-radius: 5px; /* Keep or match button radius if desired, 5px is fine */
-            border: 1px solid #f1c40f;
-            background-color: #2c3e50;
-            color: white;
+            border: 1px solid var(--control-bar-select-border);
+            background-color: var(--control-bar-select-bg);
+            color: var(--control-bar-select-text);
             font-size: 0.9em;
             margin: 0 5px;
         }
@@ -133,29 +322,50 @@
             margin-right: 8px;
             font-weight: normal;
             font-size: 0.9em;
-            color: #ecf0f1; /* Lighter text for label for better readability against dark bar */
+            color: var(--control-bar-label-text);
         }
         /* Bottom Control Bar Styles END */
 
         /* Final Scorecard Table Styles START */
         .scorecard-table {
             width: 100%; border-collapse: collapse; margin-top: 15px; margin-bottom: 15px;
-            font-size: 0.9em; color: #ecf0f1;
+            font-size: 0.9em; color: var(--scorecard-table-text);
         }
         .scorecard-table th, .scorecard-table td {
-            border: 1px solid #4a6572; padding: 8px 10px; text-align: left;
+            border: 1px solid var(--scorecard-table-border);
+            padding: 8px 10px; text-align: left;
         }
         .scorecard-table th {
-            background-color: #34495e; color: #f1c40f; font-weight: bold;
+            background-color: var(--scorecard-table-header-bg);
+            color: var(--scorecard-table-header-text); font-weight: bold;
         }
-        .scorecard-table tbody tr:nth-child(odd) { background-color: #3b5363; }
-        .scorecard-table tbody tr:hover { background-color: #4a6572; }
+        .scorecard-table tbody tr:nth-child(odd) { background-color: var(--scorecard-table-row-odd-bg); }
+        .scorecard-table tbody tr:hover { background-color: var(--scorecard-table-row-hover-bg); }
         .result-highlight-replay { /* Style for result in final scorecard */
-             margin-top:20px; padding:15px; text-align:center; background-color: #27ae60;
-             color:white; border-radius: 5px;
+             margin-top:20px; padding:15px; text-align:center;
+             background-color: var(--result-highlight-replay-bg);
+             color: var(--result-highlight-replay-text); border-radius: 5px;
         }
-        .result-highlight-replay h4 {color: white;}
+        .result-highlight-replay h4 {color: var(--result-highlight-replay-text);} /* Ensure h4 color matches text */
          /* Final Scorecard Table Styles END */
+
+        #themeToggleBtnBallByBall {
+            background-color: var(--new-match-button-bg);
+            color: var(--new-match-button-text);
+            border: 1px solid var(--new-match-button-bg);
+            border-radius: 20px;
+            padding: 8px 15px;
+            font-weight: bold;
+            font-size: 0.9em;
+            cursor: pointer;
+            margin-left: 10px;
+            transition: background-color 0.2s ease, color 0.2s ease;
+        }
+
+        #themeToggleBtnBallByBall:hover {
+            background-color: var(--new-match-button-hover-bg);
+            color: var(--new-match-button-text); /* Assuming hover bg still contrasts with this */
+        }
 
         /* CSS for Modal */
         .modal-overlay {
@@ -164,7 +374,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background-color: rgba(0, 0, 0, 0.85); /* Dark overlay */
+            background-color: var(--modal-overlay-bg);
             z-index: 2000; /* High z-index */
             display: none; /* Hidden by default */
             align-items: center; /* For centering content if needed, though content will be scrollable */
@@ -174,7 +384,7 @@
         }
 
         .modal-content {
-            background-color: #2c3e50; /* Match existing style */
+            background-color: var(--modal-content-bg);
             padding: 25px;
             border-radius: 8px;
             width: 100%;
@@ -191,21 +401,24 @@
             right: 15px;
             font-size: 28px;
             font-weight: bold;
-            color: #f1c40f; /* Accent color */
+            color: var(--modal-close-button-text);
             background: none;
             border: none;
             cursor: pointer;
             line-height: 1;
         }
         .close-modal-button:hover {
-            color: #ffffff; /* Brighter on hover */
+            color: var(--modal-close-button-hover-text);
         }
     </style>
 </head>
 <body>
     <header class="match-header">
         <div class="header-title"><h1>{{ team1_short_name }} vs {{ team2_short_name }}</h1></div>
-        <div class="header-actions"><form action="{{ url_for('index') }}" method="get" style="margin: 0;"><button type="submit" class="new-match-button">New Match</button></form></div>
+        <div class="header-actions">
+            <form action="{{ url_for('index') }}" method="get" style="margin: 0; display: inline-block;"><button type="submit" class="new-match-button">New Match</button></form>
+            <button id="themeToggleBtnBallByBall" style="padding: 8px 12px; margin-left: 10px; cursor: pointer;">Toggle Theme</button>
+        </div>
     </header>
 
     <div class="container">
@@ -249,7 +462,7 @@
         <div id="finalScorecardModal" class="modal-overlay" style="display: none;">
             <div id="finalScorecardDisplay" class="modal-content" style="margin-top: 0;">
                 <button id="closeScorecardModalBtn" class="close-modal-button">&times;</button>
-                <h2 style="text-align: center; color: #f1c40f; margin-bottom: 20px;">Full Match Scorecard</h2>
+                <h2 style="text-align: center; color: var(--heading-color); margin-bottom: 20px;">Full Match Scorecard</h2>
                 {# Content will be generated by JavaScript by generateFullScorecardHTML() #}
             </div>
         </div>
@@ -303,6 +516,7 @@
         const firstInningsScorecardDiv = document.getElementById('firstInningsScorecardDisplay');
         const finalScorecardModal = document.getElementById('finalScorecardModal');
         const closeScorecardModalBtn = document.getElementById('closeScorecardModalBtn');
+        const bottomControlBar = document.querySelector('.bottom-control-bar');
 
 
         let innings1Log = fullMatchData.innings1_log || [];
@@ -486,7 +700,7 @@
             let batTeamName = (teamsFullData[batTeamCode.toLowerCase()] ? teamsFullData[batTeamCode.toLowerCase()].fullName : batTeamCode.toUpperCase());
             let bowlTeamName = (teamsFullData[bowlTeamCode.toLowerCase()] ? teamsFullData[bowlTeamCode.toLowerCase()].fullName : bowlTeamCode.toUpperCase());
 
-            let html = `<h4 style="color: #ecf0f1; margin-top: 20px;">Innings ${inningsNum}: ${batTeamName}</h4>`;
+            let html = `<h4 style="color: var(--scorecard-table-text); margin-top: 20px;">Innings ${inningsNum}: ${batTeamName}</h4>`; // Use variable for h4 color
             html += '<table class="scorecard-table"><thead><tr><th>Player</th><th>How Out</th><th>Runs</th><th>Balls</th><th>SR</th></tr></thead><tbody>';
 
             if (battracker && typeof battracker === 'object') {
@@ -502,9 +716,9 @@
             }
             html += '</tbody></table>';
             const oversStr = formatOver(inningsBalls);
-            html += `<p style="color: #bdc3c7; font-weight: bold;">Total: ${inningsRuns}/${inningsWickets} (${oversStr} Overs)</p>`;
+            html += `<p style="color: var(--scorecard-table-text); font-weight: bold;">Total: ${inningsRuns}/${inningsWickets} (${oversStr} Overs)</p>`; // Use variable
 
-            html += `<h5 style="color: #ecf0f1; margin-top:15px;">Bowling: ${bowlTeamName}</h5>`;
+            html += `<h5 style="color: var(--scorecard-table-text); margin-top:15px;">Bowling: ${bowlTeamName}</h5>`; // Use variable
             html += '<table class="scorecard-table"><thead><tr><th>Player</th><th>Overs</th><th>Runs</th><th>Wickets</th><th>Economy</th></tr></thead><tbody>';
             if (bowltracker && typeof bowltracker === 'object') {
                 for (const playerInitial in bowltracker) {
@@ -518,13 +732,14 @@
                     html += `<tr><td>${playerName}</td><td>${overs}</td><td>${runsConceded}</td><td>${wicketsTaken}</td><td>${economy}</td></tr>`;
                 }
             }
-            html += '</tbody></table> <hr style="border-color: #444; margin-top: 20px; margin-bottom: 10px;">';
+            html += '</tbody></table> <hr style="border-color: var(--log-entry-border); margin-top: 20px; margin-bottom: 10px;">'; // Use variable
             return html;
         }
 
         function generateFullScorecardHTML(matchData) {
             let html = `<div style="padding:10px;">`;
-            html += `<h3 style="color: #ecf0f1; text-align:center; margin-bottom:15px;">${matchData.toss_msg}</h3> <hr style="border-color: #444; margin-bottom:20px;">`;
+            // The main H2 "Full Match Scorecard" is static in the modal. This H3 is for the toss message.
+            html += `<h3 style="color: var(--subheading-color); text-align:center; margin-bottom:15px;">${matchData.toss_msg}</h3> <hr style="border-color: var(--log-entry-border); margin-bottom:20px;">`; // Use variables
 
             const teamsDataForFunc = { // Create a map for easy lookup by code
                 [matchData.team1_code.toLowerCase()]: matchData.team1_data,
@@ -574,6 +789,14 @@
             // finalScorecardDiv.style.display = 'none'; // Content area, not modal itself
             if (finalScorecardModal) finalScorecardModal.style.display = 'none'; // Hide modal at start
             if (firstInningsScorecardDiv) firstInningsScorecardDiv.style.display = 'none';
+            if (bottomControlBar) bottomControlBar.style.display = 'flex'; // Ensure control bar is visible
+
+            // Set initial button states correctly without calling disableControls()
+            nextBallBtn.disabled = false;
+            startAutoPlayBtn.disabled = false;
+            startAutoPlayBtn.classList.remove('hidden');
+            pauseAutoPlayBtn.classList.add('hidden');
+            pauseAutoPlayBtn.disabled = true; // Important: Pause should be disabled initially
         }
 
         function handleEndOfMatch() {
@@ -591,6 +814,7 @@
             finalScorecardDiv.innerHTML = scorecardHTML; // Populate the content area
 
             if (finalScorecardModal) finalScorecardModal.style.display = 'flex'; // Show modal
+            if (bottomControlBar) bottomControlBar.style.display = 'none'; // Hide the control bar
 
             // Hide first innings scorecard if it's still visible
             if (firstInningsScorecardDiv) {
@@ -670,8 +894,41 @@
         if (closeScorecardModalBtn && finalScorecardModal) {
             closeScorecardModalBtn.addEventListener('click', () => {
                 finalScorecardModal.style.display = 'none';
+                if (bottomControlBar) bottomControlBar.style.display = 'flex'; // Show the control bar again
             });
         }
+
+        // Theme Toggle Logic for replay_ball_by_ball.html
+        const themeToggleBtnReplay = document.getElementById('themeToggleBtnBallByBall');
+        const currentThemeReplay = localStorage.getItem('theme'); // Use the same localStorage key 'theme'
+
+        function applyThemeReplay(theme) {
+            if (theme === 'dark') {
+                document.body.setAttribute('data-theme', 'dark');
+                if (themeToggleBtnReplay) themeToggleBtnReplay.textContent = 'Light Mode';
+            } else {
+                document.body.setAttribute('data-theme', 'light');
+                if (themeToggleBtnReplay) themeToggleBtnReplay.textContent = 'Dark Mode';
+            }
+        }
+
+        if (currentThemeReplay) {
+            applyThemeReplay(currentThemeReplay);
+        } else {
+            applyThemeReplay('light'); // Default to light theme
+        }
+
+        if (themeToggleBtnReplay) {
+            themeToggleBtnReplay.addEventListener('click', () => {
+                let newTheme = 'light';
+                if (document.body.getAttribute('data-theme') === 'light') {
+                    newTheme = 'dark';
+                }
+                applyThemeReplay(newTheme);
+                localStorage.setItem('theme', newTheme);
+            });
+        }
+        // End of Theme Toggle Logic
 
         initializeReplay();
     </script>


### PR DESCRIPTION
This commit addresses your feedback by introducing a light/dark theme toggle, adjusting button styles, and further refining UI interactions for both direct and ball-by-ball scorecards.

**Key Changes:**

1.  **Theme Toggle Functionality (`index.html`, `replay_ball_by_ball.html`):**
    *   I implemented CSS variables for comprehensive theming on both pages.
        *   `index.html`: Default light theme, with a dark theme option.
        *   `replay_ball_by_ball.html`: Default light theme, with its original dark appearance as the dark theme option.
    *   I added a theme toggle button to both pages.
    *   JavaScript logic handles theme switching by toggling a `data-theme`
        attribute on the body and persists your preference via
        `localStorage`. Button text updates to reflect the current mode.

2.  **Direct Scorecard (`index.html`):**
    *   I adjusted the "Simulate Another Match" floating button style from
        a circle to a pill-shaped (rounded rectangle) button as per your feedback.

3.  **Ball-by-Ball Replay (`replay_ball_by_ball.html`):**
    *   **Pause Button Visibility**: I re-verified and confirmed the robustness
        of the JavaScript logic ensuring the "Pause" button is correctly
        displayed when "Auto-Play" is active.
    *   **Full-Screen Scorecard Controls**: The main bottom control bar
        (with "Next Ball", "Speed", "Auto-Play" buttons) is now hidden
        when the full-screen final scorecard modal is displayed at the end
        of the match. The bar reappears (controls still disabled) if the
        modal is closed. The modal's existing close button serves to
        hide the full-screen scorecard.

These changes aim to enhance your experience by providing theme customization and addressing specific UI preferences and behaviors noted in your feedback.