### PR TITLE
Fix: Ensure scorecard close button is visible

### DIFF
--- a/IPL-1.0/templates/replay_ball_by_ball.html
+++ b/IPL-1.0/templates/replay_ball_by_ball.html
@@ -74,8 +74,8 @@
             --scorecard-table-border: #dee2e6;
             --scorecard-table-row-odd-bg: #f8f9fa;
             --scorecard-table-row-hover-bg: #e9ecef;
-            --modal-close-button-text: #007bff;
-            --modal-close-button-hover-text: #0056b3;
+            --modal-close-button-text: #6c757d;
+            --modal-close-button-hover-text: #343a40;
             --result-highlight-replay-bg: #d1ecf1;
             --result-highlight-replay-text: #0c5460;
             --first-innings-scorecard-bg: #e9ecef; /* Similar to other sections */
@@ -150,8 +150,8 @@
             --scorecard-table-border: #4a6572;
             --scorecard-table-row-odd-bg: #3b5363;
             --scorecard-table-row-hover-bg: #4a6572;
-            --modal-close-button-text: #f1c40f;
-            --modal-close-button-hover-text: #ffffff;
+            --modal-close-button-text: #adb5bd;
+            --modal-close-button-hover-text: #e9ecef;
             --result-highlight-replay-bg: #27ae60;
             --result-highlight-replay-text: white;
             --first-innings-scorecard-bg: #283740; /* Original dark theme color */


### PR DESCRIPTION
The close button ('×') on the full match scorecard modal in the ball-by-ball replay was difficult to see because its color was the same as the modal's main title in both light and dark themes.

This commit updates the CSS color variables for the close button to ensure it has sufficient contrast against both the modal background and the nearby title text in both themes, making it clearly visible.

- Light theme: Button color changed from blue to grey.
- Dark theme: Button color changed from yellow to light grey.